### PR TITLE
Allow local dev auth bypass

### DIFF
--- a/src/api/base44Client.js
+++ b/src/api/base44Client.js
@@ -1,8 +1,11 @@
 import { createClient } from '@base44/sdk';
 // import { getAccessToken } from '@base44/sdk/utils/auth-utils';
 
-// Create a client with authentication required
+// Disable auth when running the Vite dev server so the app can load without
+// logging in. This is useful for local UI development and testing.
+const bypassAuth = import.meta.env.DEV;
+
 export const base44 = createClient({
-  appId: "685939ed073c7630dbe69779", 
-  requiresAuth: true // Ensure authentication is required for all operations
+  appId: "685939ed073c7630dbe69779",
+  requiresAuth: !bypassAuth
 });

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -14,4 +14,31 @@ export const UserSettings = base44.entities.UserSettings;
 
 
 // auth sdk:
-export const User = base44.auth;
+const baseUser = base44.auth;
+
+// When developing locally, bypass authentication by returning a mock user and
+// stubbing out login/logout methods. This allows the app to run without hitting
+// the real auth endpoints.
+const devUser = {
+  id: 'local-dev',
+  email: 'test@example.com',
+  name: 'Test User',
+};
+
+export const User = import.meta.env.DEV
+  ? {
+      async me() {
+        window.user = devUser;
+        return devUser;
+      },
+      async login() {
+        console.log('Bypassing login for local dev');
+        window.user = devUser;
+        return devUser;
+      },
+      async logout() {
+        console.log('Bypassing logout for local dev');
+        window.user = null;
+      },
+    }
+  : baseUser;


### PR DESCRIPTION
## Summary
- allow turning off Base44 authentication when running the Vite dev server
- provide a mocked `User` implementation in dev mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e567f45883319e7bfcb380bc64f9