### PR TITLE
Annotate offline behavior for Base44 SDK

### DIFF
--- a/src/api/base44Client.js
+++ b/src/api/base44Client.js
@@ -6,9 +6,11 @@ import { createClient } from '@base44/sdk';
 // behaviour can also be toggled explicitly via the VITE_DISABLE_AUTH env
 // variable.
 const isDev = import.meta.env.DEV;
+// When true, Base44 client will not require an auth token.
 const disableAuth = isDev || import.meta.env.VITE_DISABLE_AUTH === 'true';
 
 export const base44 = createClient({
   appId: "685939ed073c7630dbe69779",
+  // Skip auth requirement in dev/offline mode
   requiresAuth: !disableAuth
 });

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -1,14 +1,19 @@
 import { base44 } from './base44Client';
 
 
+// ⚠️ Still makes real API calls even when auth is disabled
 export const Task = base44.entities.Task;
 
+// ⚠️ Still makes real API calls even when auth is disabled
 export const Tab = base44.entities.Tab;
 
+// ⚠️ Still makes real API calls even when auth is disabled
 export const UserHabit = base44.entities.UserHabit;
 
+// ⚠️ Still makes real API calls even when auth is disabled
 export const UserHabitCompletion = base44.entities.UserHabitCompletion;
 
+// ⚠️ Still makes real API calls even when auth is disabled
 export const UserSettings = base44.entities.UserSettings;
 
 
@@ -29,6 +34,7 @@ const devUser = {
 const isDev = import.meta.env.DEV;
 const disableAuth = isDev || import.meta.env.VITE_DISABLE_AUTH === 'true';
 
+// ✅ Returns a mock user and stubs login/logout when auth is disabled
 export const User = disableAuth
   ? {
       async me() {


### PR DESCRIPTION
## Summary
- add inline docs about disabling auth in `base44Client.js`
- mark which exported API wrappers hit live endpoints in `entities.js`
- document that the mock user object is provided when auth is disabled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860fd5cd6148331a8a571a0e7272560