### PR TITLE
Add mock UserSettings entity for disabled auth

### DIFF
--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -100,8 +100,27 @@ export const UserHabitCompletion = authDisabled
         base44.entities.UserHabitCompletion.deleteCompletion(id),
     };
 
-// ⚠️ Still makes real API calls even when auth is disabled
-export const UserSettings = base44.entities.UserSettings;
+// UserSettings entity
+let mockSettings = {
+  dailyReminder: true,
+  startOfWeek: 'Sunday',
+  theme: 'light',
+};
+
+export const UserSettings = authDisabled
+  ? {
+      async getSettings() {
+        return mockSettings;
+      },
+      async updateSettings(changes) {
+        mockSettings = {
+          ...mockSettings,
+          ...changes,
+        };
+        return mockSettings;
+      },
+    }
+  : base44.entities.UserSettings;
 
 
 


### PR DESCRIPTION
## Summary
- mock `UserSettings` in `src/api/entities.js` when auth is disabled
- implement `getSettings` and `updateSettings` using a local `mockSettings` object

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68610555af888331815e506a01ac0f63