### PR TITLE
Fix offline mock errors

### DIFF
--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -111,6 +111,9 @@ let mockHabits = [
 
 export const UserHabit = authDisabled
   ? {
+      async list() {
+        return mockHabits;
+      },
       async getHabits() {
         return mockHabits;
       },
@@ -153,6 +156,9 @@ let mockCompletions = [];
 
 export const UserHabitCompletion = authDisabled
   ? {
+      async list() {
+        return mockCompletions;
+      },
       async getCompletionsByHabit(habitId) {
         return mockCompletions.filter((c) => c.user_habit_id === habitId);
       },
@@ -189,7 +195,14 @@ let mockSettings = {
 
 export const UserSettings = authDisabled
   ? {
+      async list() {
+        return [mockSettings];
+      },
       async getSettings() {
+        return mockSettings;
+      },
+      async update(id, changes) {
+        Object.assign(mockSettings, changes);
         return mockSettings;
       },
       async updateSettings(changes) {


### PR DESCRIPTION
## Summary
- update mocked entity APIs to match SDK during offline dev

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68610a73cc388331b443d29a1d96ef92