### PR TITLE
Fix UserHabit.create in mock mode

### DIFF
--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -127,6 +127,16 @@ export const UserHabit = authDisabled
         mockHabits.push(newHabit);
         return newHabit;
       },
+      async create(data) {
+        const newHabit = {
+          ...data,
+          id: `mock-${Date.now()}`,
+          created_date: new Date().toISOString(),
+          updated_date: new Date().toISOString(),
+        };
+        mockHabits.push(newHabit);
+        return newHabit;
+      },
       async updateHabit(id, changes) {
         const index = mockHabits.findIndex((h) => h.id === id);
         if (index !== -1) {


### PR DESCRIPTION
## Summary
- add `create` method to the `UserHabit` mock so offline mode matches the real API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68610cf1ba388331a1fe4c70f5b3bcd7