### PR TITLE
Fix offline duplication for new items

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -355,13 +355,13 @@ export default function Dashboard({ setPageTitle, setPageActions }) {
     
     try {
       const createdHabit = await DataManager.createHabit(newHabit);
-      
+
       if (habitData.reminder_enabled && habitData.reminder_time) {
         await handleReminderToggle(createdHabit.id, createdHabit.name, createdHabit.emoji, createdHabit.reminder_time, true);
       }
-      
-      const updatedHabits = [...habits, createdHabit];
-      setHabits(updatedHabits);
+
+      const freshHabits = await DataManager.getHabits();
+      setHabits(freshHabits);
       setShowForm(false);
       setEditingHabit(null);
     } catch (error) {

--- a/src/pages/ToDo.jsx
+++ b/src/pages/ToDo.jsx
@@ -365,8 +365,9 @@ export default function ToDo({ setPageTitle, setPageActions }) {
     };
     
     try {
-        const createdTask = await DataManager.createTask(newTaskData);
-        setTasks(prevTasks => [createdTask, ...prevTasks]);
+        await DataManager.createTask(newTaskData);
+        const updatedTasks = await DataManager.getTasks();
+        setTasks(updatedTasks);
     } catch (error) {
         console.error("Failed to create task:", error);
     }
@@ -409,8 +410,9 @@ export default function ToDo({ setPageTitle, setPageActions }) {
       };
       
       const createdTab = await DataManager.createTab(newTab);
-      const updatedTabs = [...tabs, createdTab].sort((a, b) => (a.sort_order || 0) - (b.sort_order || 0));
-      setTabs(updatedTabs);
+      const freshTabs = await DataManager.getTabs();
+      const sortedTabs = freshTabs.sort((a, b) => (a.sort_order || 0) - (b.sort_order || 0));
+      setTabs(sortedTabs);
       setActiveTab(createdTab);
       setShowAddTab(false);
     } catch (error) {


### PR DESCRIPTION
## Summary
- refresh tasks from the data source after creating a new task
- fetch tabs list after creating a custom tab
- refresh habits list after creating a habit

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68611f528d208331922edb4bd8513820