### PR TITLE
Restore header kebab menus

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import React, { useState, useEffect, useCallback, useRef, useContext } from "react";
 import { User } from '@/api/entities'; // Import User entity
 import DataManager from "../components/DataManager"; // Import DataManager
 import { Button } from "@/components/ui/button";
@@ -31,8 +31,12 @@ import CelebrationCard from "../components/CelebrationCard";
 import notificationManager from "../components/NotificationManager";
 import ReorderHabitsModal from "../components/ReorderHabitsModal";
 import UnifiedLoader from "../components/UnifiedLoader";
+import { LayoutContext } from "./Layout";
 
 export default function Dashboard({ setPageTitle, setPageActions }) {
+  const { setPageTitle: ctxSetPageTitle, setPageActions: ctxSetPageActions } = useContext(LayoutContext);
+  const pageTitleSetter = setPageTitle || ctxSetPageTitle;
+  const pageActionsSetter = setPageActions || ctxSetPageActions;
   const [habits, setHabits] = useState([]);
   const [completions, setCompletions] = useState([]);
   const [showForm, setShowForm] = useState(false);
@@ -55,9 +59,9 @@ export default function Dashboard({ setPageTitle, setPageActions }) {
 
   useEffect(() => {
     // Set page title and actions for the Layout
-    if (setPageTitle) setPageTitle("Today");
-    if (setPageActions) {
-      setPageActions(
+    if (pageTitleSetter) pageTitleSetter("Today");
+    if (pageActionsSetter) {
+      pageActionsSetter(
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -77,7 +81,7 @@ export default function Dashboard({ setPageTitle, setPageActions }) {
         </DropdownMenu>
       );
     }
-  }, [setPageTitle, setPageActions]);
+  }, [pageTitleSetter, pageActionsSetter]);
 
   const loadData = useCallback(async () => { // Renamed from loadLocalData and made async
     setIsLoading(true);

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -1,6 +1,6 @@
 
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, createContext } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { createPageUrl } from "../utils";
 import { User } from '@/api/entities';
@@ -13,6 +13,12 @@ import notificationManager from "../components/NotificationManager";
 import { LayoutList, CheckSquare, Menu, UserCircle2, X } from "lucide-react";
 import SettingsModal from "../components/SettingsModal"; // Assuming SettingsModal is in components
 import StatisticsModal from "../components/StatisticsModal"; // Import the new modal
+
+// Context for child pages to access layout controls when they are not passed as props
+export const LayoutContext = createContext({
+  setPageTitle: () => {},
+  setPageActions: () => {},
+});
 
 const navItems = [
   { href: "/Dashboard", icon: LayoutList, label: "Habits" },
@@ -135,6 +141,7 @@ export default function Layout({ children, currentPageName }) {
   });
 
   return (
+    <LayoutContext.Provider value={{ setPageTitle, setPageActions }}>
     <div className="min-h-screen bg-[#f4f8fc] flex flex-col">
       {/* Unified App Header */}
       <header className="fixed top-0 left-0 right-0 z-30 bg-[#f4f8fc]/90 backdrop-blur-sm">
@@ -233,6 +240,7 @@ export default function Layout({ children, currentPageName }) {
         onClose={() => setShowStatsModal(false)}
       />
     </div>
+    </LayoutContext.Provider>
   );
 }
 

--- a/src/pages/ToDo.jsx
+++ b/src/pages/ToDo.jsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { User } from "@/api/entities";
 import DataManager from "../components/DataManager";
 import { Button } from "@/components/ui/button";
@@ -20,6 +20,7 @@ import TabManagementModal from "../components/todo/TabManagementModal";
 import AddTabModal from "../components/todo/AddTabModal";
 import { calculateSortValue, mapEnumsToValues } from "../components/todo/sortValueCalculator";
 import UnifiedLoader from "../components/UnifiedLoader";
+import { LayoutContext } from "./Layout";
 
 const DEFAULT_TODO_SETTINGS = {
   cardFields: {
@@ -62,6 +63,9 @@ const isDoneToday = (doneDate) => {
 };
 
 export default function ToDo({ setPageTitle, setPageActions }) {
+  const { setPageTitle: ctxSetPageTitle, setPageActions: ctxSetPageActions } = useContext(LayoutContext);
+  const pageTitleSetter = setPageTitle || ctxSetPageTitle;
+  const pageActionsSetter = setPageActions || ctxSetPageActions;
   const [tasks, setTasks] = useState([]);
   const [tabs, setTabs] = useState([]);
   const [activeTab, setActiveTab] = useState(null);
@@ -77,11 +81,11 @@ export default function ToDo({ setPageTitle, setPageActions }) {
 
   useEffect(() => {
     // Set page title and actions for the Layout
-    if (setPageTitle) {
-      setPageTitle(activeTab ? activeTab.name : "ToDo");
+    if (pageTitleSetter) {
+      pageTitleSetter(activeTab ? activeTab.name : "ToDo");
     }
-    if (setPageActions) {
-      setPageActions(
+    if (pageActionsSetter) {
+      pageActionsSetter(
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -101,7 +105,7 @@ export default function ToDo({ setPageTitle, setPageActions }) {
         </DropdownMenu>
       );
     }
-  }, [setPageTitle, setPageActions, activeTab]);
+  }, [pageTitleSetter, pageActionsSetter, activeTab]);
 
   // Add a more controlled settings update listener
   useEffect(() => {


### PR DESCRIPTION
## Summary
- provide LayoutContext so child pages can control header
- consume LayoutContext in Dashboard and ToDo pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686125308c40833181a5525216dbc5af