### PR TITLE
Fix Done tab in ToDo offline mode

### DIFF
--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -45,7 +45,8 @@ let mockTabs = [
   { id: 'mock-tab-2', name: 'Today', sort_order: 1, type: 'Preset' },
   { id: 'mock-tab-3', name: 'Tomorrow', sort_order: 2, type: 'Preset' },
   { id: 'mock-tab-4', name: 'Archive', sort_order: 3, type: 'Preset' },
-  { id: 'mock-tab-5', name: 'Upcoming', sort_order: 4, type: 'Custom' },
+  { id: 'mock-tab-5', name: 'Done', sort_order: 4, type: 'Preset' },
+  { id: 'mock-tab-6', name: 'Upcoming', sort_order: 5, type: 'Custom' },
 ];
 
 export const Tab = authDisabled

--- a/src/pages/ToDo.jsx
+++ b/src/pages/ToDo.jsx
@@ -190,6 +190,7 @@ export default function ToDo({ setPageTitle, setPageActions }) {
         { name: 'Inbox', type: 'Preset' },
         { name: 'Today', type: 'Preset' },
         { name: 'Tomorrow', type: 'Preset' },
+        { name: 'Done', type: 'Preset' },
         { name: 'Archive', type: 'Preset' }
       ];
 


### PR DESCRIPTION
## Summary
- include Done in mock preset tabs
- ensure Done is created during ToDo initialization when missing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68612cf43dfc8331abd5e71f0fc2f92c