### PR TITLE
Refactor bottom navigation UI

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -10,7 +10,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/co
 import WeekStartBottomSheet from "../components/WeekStartBottomSheet";
 import NotificationConfirmDialog from "../components/NotificationConfirmDialog";
 import notificationManager from "../components/NotificationManager";
-import { LayoutList, CheckSquare, Menu, UserCircle2, X } from "lucide-react";
+import { CheckSquare, Flame, Menu, UserCircle2, X } from "lucide-react";
 import SettingsModal from "../components/SettingsModal"; // Assuming SettingsModal is in components
 import StatisticsModal from "../components/StatisticsModal"; // Import the new modal
 
@@ -21,9 +21,20 @@ export const LayoutContext = createContext({
 });
 
 const navItems = [
-  { href: "/Dashboard", icon: LayoutList, label: "Habits" },
+  { href: "/Dashboard", icon: Flame, label: "Habits" },
   { href: "/ToDo", icon: CheckSquare, label: "ToDo" },
 ];
+
+function TabIcon({ Icon, active }) {
+  return (
+    <Icon
+      className="w-6 h-6"
+      strokeWidth={2}
+      stroke="currentColor"
+      fill={active ? "currentColor" : "none"}
+    />
+  );
+}
 
 export default function Layout({ children, currentPageName }) {
   const location = useLocation();
@@ -212,11 +223,16 @@ export default function Layout({ children, currentPageName }) {
       <div className="fixed bottom-0 left-0 right-0 h-safe-bottom bg-white border-t border-slate-200 z-40">
         <div className="flex justify-around items-center h-16">
           {navItems.map((item) => {
-            const isActive = location.pathname === item.href || (item.href === "/Dashboard" && location.pathname === "/");
+            const isActive =
+              location.pathname === item.href ||
+              (item.href === "/Dashboard" && location.pathname === "/");
             return (
-              <Link key={item.label} to={item.href} className={`flex flex-col items-center justify-center w-full h-full transition-colors duration-200 ${isActive ? 'text-blue-600' : 'text-slate-500 hover:text-blue-500'}`}>
-                <item.icon className="w-6 h-6" strokeWidth={isActive ? 2.5 : 2} />
-                <span className={`mt-1 text-xs font-medium ${isActive ? 'font-semibold' : ''}`}>{item.label}</span>
+              <Link
+                key={item.label}
+                to={item.href}
+                className="flex items-center justify-center w-full h-full text-slate-600"
+              >
+                <TabIcon Icon={item.icon} active={isActive} />
               </Link>
             );
           })}


### PR DESCRIPTION
## Summary
- refactor bottom navigation
- use flame icon for the "Habits" tab
- switch icons between outline and solid by using a new `TabIcon` helper
- remove text labels and keep icon color constant

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861411e31f48331a1cd1182cb2e2cf8