### PR TITLE
Add padding for Approve Delete button

### DIFF
--- a/src/components/todo/TabManagementModal.jsx
+++ b/src/components/todo/TabManagementModal.jsx
@@ -217,7 +217,7 @@ export default function TabManagementModal({ isOpen, onClose, tabs, onSaveTabs }
                                     animate={{ opacity: 1, x: 0 }}
                                     exit={{ opacity: 0, x: 40 }}
                                     transition={{ type: 'tween', duration: 0.2 }}
-                                    className="absolute inset-y-0 right-0 flex items-center pr-4 bg-red-500 rounded-lg z-0"
+                                    className="absolute inset-y-0 right-0 flex justify-end items-center pr-4 pl-6 bg-red-500 rounded-lg z-0"
                                   >
                                     <button
                                       onClick={() => confirmDelete(tab)}


### PR DESCRIPTION
## Summary
- adjust delete confirmation strip styling so `Approve Delete` text is fully visible

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68615a757edc83319f5468214e139a5d