### PR TITLE
Add due date badges with urgency labels

### DIFF
--- a/src/components/todo/TaskItem.jsx
+++ b/src/components/todo/TaskItem.jsx
@@ -4,7 +4,7 @@ import { Card } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import { Calendar, Flag, Zap, Timer } from "lucide-react";
-import { format } from "date-fns";
+import { getDueDateInfo } from "@/utils/dateUtils";
 
 const DEFAULT_CARD_SETTINGS = {
   description: false,
@@ -101,12 +101,15 @@ export default function TaskItem({ task, onStatusChange, onEdit, cardSettings = 
               )}
 
               {/* Due Date */}
-              {cardSettings.dueDate && task.dueDate && (
-                <Badge variant="outline">
-                  <Calendar className="w-3 h-3 mr-1" />
-                  {format(new Date(task.dueDate), 'MMM d')}
-                </Badge>
-              )}
+              {cardSettings.dueDate && task.dueDate && (() => {
+                const { label, variant } = getDueDateInfo(task.dueDate);
+                return (
+                  <Badge variant={variant}>
+                    <Calendar className="w-3 h-3 mr-1" />
+                    {label}
+                  </Badge>
+                );
+              })()}
 
               {/* Scheduled Time */}
               {cardSettings.scheduledTime && task.scheduledTime && (

--- a/src/components/ui/badge.jsx
+++ b/src/components/ui/badge.jsx
@@ -14,6 +14,8 @@ const badgeVariants = cva(
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        warning:
+          "border-transparent bg-yellow-100 text-yellow-800",
         outline: "text-foreground",
       },
     },

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -1,0 +1,41 @@
+import {
+  format,
+  isToday,
+  isTomorrow,
+  isBefore,
+  differenceInCalendarDays,
+  parseISO,
+} from 'date-fns'
+
+export function getDueDateInfo(dueDateStr) {
+  if (!dueDateStr) return { label: "", variant: "outline" };
+
+  const dueDate = parseISO(dueDateStr)
+  const today = new Date()
+
+  if (isToday(dueDate)) {
+    return { label: "Due today", variant: "destructive" }
+  }
+
+  if (isTomorrow(dueDate)) {
+    return { label: "Due tomorrow", variant: "warning" }
+  }
+
+  if (isBefore(dueDate, today)) {
+    return { label: "Overdue", variant: "destructive" }
+  }
+
+  const daysUntilDue = differenceInCalendarDays(dueDate, today)
+
+  if (daysUntilDue <= 5) {
+    return {
+      label: `Due in ${daysUntilDue} day${daysUntilDue === 1 ? "" : "s"}`,
+      variant: "default",
+    }
+  }
+
+  return {
+    label: format(dueDate, "MMM d"),
+    variant: "outline",
+  }
+}


### PR DESCRIPTION
## Summary
- add `getDueDateInfo` helper to compute urgency labels
- show dynamic due-date labels on task cards
- add new `warning` badge variant for yellow badges

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686166d732708331a5d78cf0e59a8f28