### PR TITLE
Enhance due date badges on task cards

### DIFF
--- a/src/components/todo/TaskItem.jsx
+++ b/src/components/todo/TaskItem.jsx
@@ -4,7 +4,13 @@ import { Card } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import { Calendar, Flag, Zap, Timer } from "lucide-react";
-import { format } from "date-fns";
+import {
+  getTodayString,
+  isToday,
+  isTomorrow,
+  isDateInRange,
+  compareDateStrings,
+} from "@/components/dateUtils";
 
 const DEFAULT_CARD_SETTINGS = {
   description: false,
@@ -36,10 +42,54 @@ export default function TaskItem({ task, onStatusChange, onEdit, cardSettings = 
 
   const effortLabels = {
     S: "Small",
-    M: "Medium", 
+    M: "Medium",
     L: "Large",
     XL: "Extra Large"
   };
+
+  function getDueDateBadgeProps(dueDate) {
+    if (!dueDate) return null;
+
+    const today = getTodayString();
+
+    if (isToday(dueDate)) {
+      return {
+        label: "Due today",
+        color: "bg-yellow-100 text-yellow-800 border-yellow-200",
+      };
+    }
+
+    if (isTomorrow(dueDate)) {
+      return {
+        label: "Due tomorrow",
+        color: "bg-blue-100 text-blue-800 border-blue-200",
+      };
+    }
+
+    if (compareDateStrings(dueDate, today) < 0) {
+      return {
+        label: "Overdue",
+        color: "bg-red-100 text-red-800 border-red-200",
+      };
+    }
+
+    const daysUntilDue =
+      (new Date(dueDate) - new Date(today)) / (1000 * 60 * 60 * 24);
+
+    if (daysUntilDue <= 5) {
+      return {
+        label: `Due in ${Math.round(daysUntilDue)} day${
+          daysUntilDue === 1 ? "" : "s"
+        }`,
+        color: "bg-green-100 text-green-800 border-green-200",
+      };
+    }
+
+    return {
+      label: dueDate,
+      color: "bg-slate-100 text-slate-800 border-slate-200",
+    };
+  }
 
   return (
     <motion.div
@@ -101,12 +151,15 @@ export default function TaskItem({ task, onStatusChange, onEdit, cardSettings = 
               )}
 
               {/* Due Date */}
-              {cardSettings.dueDate && task.dueDate && (
-                <Badge variant="outline">
-                  <Calendar className="w-3 h-3 mr-1" />
-                  {format(new Date(task.dueDate), 'MMM d')}
-                </Badge>
-              )}
+              {cardSettings.dueDate && task.dueDate && (() => {
+                const badge = getDueDateBadgeProps(task.dueDate);
+                return badge ? (
+                  <Badge className={`border ${badge.color}`}>
+                    <Calendar className="w-3 h-3 mr-1" />
+                    {badge.label}
+                  </Badge>
+                ) : null;
+              })()}
 
               {/* Scheduled Time */}
               {cardSettings.scheduledTime && task.scheduledTime && (


### PR DESCRIPTION
## Summary
- add due date badge helper to `TaskItem`
- highlight due dates using `dateUtils` helpers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616da020588331a69e238d0b97326a